### PR TITLE
Use a dedicated type to store the claims in the HTTP context

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Parsing of environment provided by the Authorization Server e.g. IAS broker
 # Usage
 
 The client library works as a middleware and has to be instantiated with `NewAuthMiddelware`. For authentication there are options: 
- - Ready-to-use **Middleware Handler**: The `Handler` which implements the standard `http/Handler` interface. Thus, it can be used easily e.g. in an `gorilla/mux` router or a plain `http/Server` implementation. The property name can be specified with the `UserContext` option and has to be type asserted to `(*core.OIDCClaims)` for the property accessors to be available.
+ - Ready-to-use **Middleware Handler**: The `Handler` which implements the standard `http/Handler` interface. Thus, it can be used easily e.g. in an `gorilla/mux` router or a plain `http/Server` implementation. The claims can be retrieved with `auth.GetClaims(req)` in the HTTP handler.
  - **Authenticate func**: More flexible, can be wrapped with an own middleware func to propagate the users claims. 
 
  
@@ -32,9 +32,7 @@ config, err := env.GetIASConfig()
 if err != nil {
     panic(err)
 }
-authMiddleware := auth.NewAuthMiddleware(config, auth.Options{
-    UserContext:  "user"
-})
+authMiddleware := auth.NewAuthMiddleware(config, auth.Options{})
 r.Use(authMiddleware.Handler)
 
 r.HandleFunc("/helloWorld", helloWorld).Methods("GET")

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -14,9 +14,6 @@ import (
 	"time"
 )
 
-// Deprecated: This type is no longer needed
-type UserContext string
-
 type contextKey int
 
 // authUserKey is the key that holds the authorization value (OIDCClaims) in the request context
@@ -27,7 +24,6 @@ type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
 
 // Options can be used as a argument to instantiate a AuthMiddle with NewAuthMiddleware.
 type Options struct {
-	UserContext  UserContext  // Deprecated: This property is no longer needed and has no effect
 	ErrorHandler ErrorHandler // ErrorHandler called if the jwt verification fails and the Handler middleware func is used. Default: DefaultErrorHandler
 	HTTPClient   *http.Client // HTTPClient which is used for OIDC discovery and to retrieve JWKs (JSON Web Keys). Default: basic http.Client with a timeout of 15 seconds
 }

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -14,15 +14,20 @@ import (
 	"time"
 )
 
-// UserContext is the type that holds the custom key under which the OIDCClaims are stored in the request context
+// Deprecated: This type is no longer needed
 type UserContext string
+
+type contextKey int
+
+// authUserKey is the key that holds the authorization value (OIDCClaims) in the request context
+const authUserKey contextKey = 0
 
 // ErrorHandler is the type for the Error Handler which is called on unsuccessful token validation and if the Handler middleware func is used
 type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
 
 // Options can be used as a argument to instantiate a AuthMiddle with NewAuthMiddleware.
 type Options struct {
-	UserContext  UserContext  // UserContext property under which the token is accessible in the request context. Default: "user"
+	UserContext  UserContext  // Deprecated: This property is no longer needed and has no effect
 	ErrorHandler ErrorHandler // ErrorHandler called if the jwt verification fails and the Handler middleware func is used. Default: DefaultErrorHandler
 	HTTPClient   *http.Client // HTTPClient which is used for OIDC discovery and to retrieve JWKs (JSON Web Keys). Default: basic http.Client with a timeout of 15 seconds
 }
@@ -33,6 +38,12 @@ type OAuthConfig interface {
 	GetClientSecret() string
 	GetURL() string
 	GetDomain() string
+}
+
+// GetClaims retrieves the claims of a request which
+// have been injected before via the auth middleware
+func GetClaims(r *http.Request) *OIDCClaims {
+	return r.Context().Value(authUserKey).(*OIDCClaims)
 }
 
 // AuthMiddleware is the main entrypoint to the client library, instantiate with NewAuthMiddleware. It holds information about the oAuth config and configured options.
@@ -56,9 +67,6 @@ func NewAuthMiddleware(oAuthConfig OAuthConfig, options Options) *AuthMiddleware
 	}
 	if options.ErrorHandler == nil {
 		options.ErrorHandler = DefaultErrorHandler
-	}
-	if options.UserContext == "" {
-		options.UserContext = "user"
 	}
 	if options.HTTPClient == nil {
 		options.HTTPClient = &http.Client{
@@ -99,7 +107,7 @@ func (m *AuthMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		reqWithContext := r.WithContext(context.WithValue(r.Context(), m.options.UserContext, claims))
+		reqWithContext := r.WithContext(context.WithValue(r.Context(), authUserKey, claims))
 		*r = *reqWithContext
 
 		// Continue serving http if jwt was valid

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -170,7 +170,6 @@ func GetTestHandler() http.HandlerFunc {
 func GetTestServer() (clientServer *httptest.Server, oidcServer *MockServer) {
 	mockServer, _ := NewOIDCMockServer()
 	options := Options{
-		UserContext:  "myprop",
 		ErrorHandler: nil,
 		HTTPClient:   mockServer.Server.Client(),
 	}

--- a/samples/middleware.go
+++ b/samples/middleware.go
@@ -23,9 +23,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	authMiddleware := auth.NewAuthMiddleware(config, auth.Options{
-		UserContext: "user",
-	})
+	authMiddleware := auth.NewAuthMiddleware(config, auth.Options{})
 	r.Use(authMiddleware.Handler)
 
 	r.HandleFunc("/helloWorld", helloWorld).Methods("GET")
@@ -39,6 +37,6 @@ func main() {
 }
 
 func helloWorld(w http.ResponseWriter, r *http.Request) {
-	user := r.Context().Value("user").(*auth.OIDCClaims)
+	user := auth.GetClaims(r)
 	_, _ = w.Write([]byte(fmt.Sprintf("Hello world!\nYou're logged in as %s", user.Email)))
 }


### PR DESCRIPTION
Using a dedicated private key type for the HTTP context makes it needless for the package user to know about the context key. To retrieve the key, the new function auth.GetClaims(r) is used.