### PR TITLE
Refactor AuthMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Parsing of environment provided by the Authorization Server e.g. IAS broker
 
 # Usage
 
-The client library works as a middleware and has to be instantiated with `NewAuthMiddelware`. For authentication there are options: 
+The client library works as a middleware and has to be instantiated with `NewMiddelware`. For authentication there are options: 
  - Ready-to-use **Middleware Handler**: The `Handler` which implements the standard `http/Handler` interface. Thus, it can be used easily e.g. in an `gorilla/mux` router or a plain `http/Server` implementation. The claims can be retrieved with `auth.GetClaims(req)` in the HTTP handler.
  - **Authenticate func**: More flexible, can be wrapped with an own middleware func to propagate the users claims. 
 
@@ -32,7 +32,7 @@ config, err := env.GetIASConfig()
 if err != nil {
     panic(err)
 }
-authMiddleware := auth.NewAuthMiddleware(config, auth.Options{})
+authMiddleware := auth.NewMiddleware(config, auth.Options{})
 r.Use(authMiddleware.Handler)
 
 r.HandleFunc("/helloWorld", helloWorld).Methods("GET")

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Parsing of environment provided by the Authorization Server e.g. IAS broker
 # Usage
 
 The client library works as a middleware and has to be instantiated with `NewMiddelware`. For authentication there are options: 
- - Ready-to-use **Middleware Handler**: The `Handler` which implements the standard `http/Handler` interface. Thus, it can be used easily e.g. in an `gorilla/mux` router or a plain `http/Server` implementation. The claims can be retrieved with `auth.GetClaims(req)` in the HTTP handler.
+ - Ready-to-use **Middleware Handler**: The `AuthenticationHandler` which implements the standard `http/Handler` interface. Thus, it can be used easily e.g. in an `gorilla/mux` router or a plain `http/Server` implementation. The claims can be retrieved with `auth.GetClaims(req)` in the HTTP handler.
  - **Authenticate func**: More flexible, can be wrapped with an own middleware func to propagate the users claims. 
 
  
@@ -33,7 +33,7 @@ if err != nil {
     panic(err)
 }
 authMiddleware := auth.NewMiddleware(config, auth.Options{})
-r.Use(authMiddleware.Handler)
+r.Use(authMiddleware.AuthenticationHandler)
 
 r.HandleFunc("/helloWorld", helloWorld).Methods("GET")
 

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -23,13 +23,13 @@ const UserContextKey ContextKey = 0
 // ErrorHandler is the type for the Error Handler which is called on unsuccessful token validation and if the Handler middleware func is used
 type ErrorHandler func(w http.ResponseWriter, r *http.Request, err error)
 
-// Options can be used as a argument to instantiate a AuthMiddle with NewAuthMiddleware.
+// Options can be used as a argument to instantiate a AuthMiddle with NewMiddleware.
 type Options struct {
 	ErrorHandler ErrorHandler // ErrorHandler called if the jwt verification fails and the Handler middleware func is used. Default: DefaultErrorHandler
 	HTTPClient   *http.Client // HTTPClient which is used for OIDC discovery and to retrieve JWKs (JSON Web Keys). Default: basic http.Client with a timeout of 15 seconds
 }
 
-// OAuthConfig interface has to be implemented to instantiate NewAuthMiddleware. For IAS the standard implementation IASConfig from ../env/iasConfig.go package can be used.
+// OAuthConfig interface has to be implemented to instantiate NewMiddleware. For IAS the standard implementation IASConfig from ../env/iasConfig.go package can be used.
 type OAuthConfig interface {
 	GetClientID() string
 	GetClientSecret() string
@@ -43,9 +43,9 @@ func GetClaims(r *http.Request) *OIDCClaims {
 	return r.Context().Value(UserContextKey).(*OIDCClaims)
 }
 
-// AuthMiddleware is the main entrypoint to the client library, instantiate with NewAuthMiddleware. It holds information about the oAuth config and configured options.
+// Middleware is the main entrypoint to the client library, instantiate with NewMiddleware. It holds information about the oAuth config and configured options.
 // Use either the ready to use Handler as a middleware or implement your own middleware with the help of Authenticate.
-type AuthMiddleware struct {
+type Middleware struct {
 	oAuthConfig OAuthConfig
 	options     Options
 	parser      *jwtgo.Parser
@@ -53,9 +53,9 @@ type AuthMiddleware struct {
 	sf          singleflight.Group
 }
 
-// NewAuthMiddleware instantiates a new AuthMiddleware with defaults for not provided Options.
-func NewAuthMiddleware(oAuthConfig OAuthConfig, options Options) *AuthMiddleware {
-	m := new(AuthMiddleware)
+// NewMiddleware instantiates a new Middleware with defaults for not provided Options.
+func NewMiddleware(oAuthConfig OAuthConfig, options Options) *Middleware {
+	m := new(Middleware)
 
 	if oAuthConfig != nil {
 		m.oAuthConfig = oAuthConfig
@@ -79,7 +79,7 @@ func NewAuthMiddleware(oAuthConfig OAuthConfig, options Options) *AuthMiddleware
 }
 
 // Authenticate authenticates a request and returns the Claims if successful, otherwise error
-func (m *AuthMiddleware) Authenticate(r *http.Request) (*OIDCClaims, error) {
+func (m *Middleware) Authenticate(r *http.Request) (*OIDCClaims, error) {
 	// get Token from Header
 	rawToken, err := extractRawToken(r)
 	if err != nil {
@@ -95,7 +95,7 @@ func (m *AuthMiddleware) Authenticate(r *http.Request) (*OIDCClaims, error) {
 }
 
 // Handler implements a middleware func which takes a http.Handler and
-func (m *AuthMiddleware) Handler(next http.Handler) http.Handler {
+func (m *Middleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims, err := m.Authenticate(r)
 
@@ -113,7 +113,7 @@ func (m *AuthMiddleware) Handler(next http.Handler) http.Handler {
 }
 
 // ClearCache clears the entire storage of cached oidc tenants including their JWKs
-func (m *AuthMiddleware) ClearCache() {
+func (m *Middleware) ClearCache() {
 	m.oidcTenants.Flush()
 }
 

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -174,7 +174,7 @@ func GetTestServer() (clientServer *httptest.Server, oidcServer *MockServer) {
 		HTTPClient:   mockServer.Server.Client(),
 	}
 	middleware := NewMiddleware(mockServer.Config, options)
-	server := httptest.NewTLSServer(middleware.Handler(GetTestHandler()))
+	server := httptest.NewTLSServer(middleware.AuthenticationHandler(GetTestHandler()))
 
 	return server, mockServer
 }

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -173,7 +173,7 @@ func GetTestServer() (clientServer *httptest.Server, oidcServer *MockServer) {
 		ErrorHandler: nil,
 		HTTPClient:   mockServer.Server.Client(),
 	}
-	middleware := NewAuthMiddleware(mockServer.Config, options)
+	middleware := NewMiddleware(mockServer.Config, options)
 	server := httptest.NewTLSServer(middleware.Handler(GetTestHandler()))
 
 	return server, mockServer

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -14,7 +14,7 @@ import (
 )
 
 // parseAndValidateJWT parses the token into its claims, verifies the claims and verifies the signature
-func (m *AuthMiddleware) parseAndValidateJWT(rawToken string) (*jwt.Token, error) {
+func (m *Middleware) parseAndValidateJWT(rawToken string) (*jwt.Token, error) {
 	token, parts, err := m.parser.ParseUnverified(rawToken, new(OIDCClaims))
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (m *AuthMiddleware) parseAndValidateJWT(rawToken string) (*jwt.Token, error
 	return token, nil
 }
 
-func (m *AuthMiddleware) verifySignature(t *jwt.Token, ks *oidcclient.OIDCTenant) error {
+func (m *Middleware) verifySignature(t *jwt.Token, ks *oidcclient.OIDCTenant) error {
 	jwks, err := ks.GetJWKs()
 	if err != nil {
 		return fmt.Errorf("token is unverifiable: failed to fetch token keys from remote: %v", err)
@@ -82,7 +82,7 @@ func (m *AuthMiddleware) verifySignature(t *jwt.Token, ks *oidcclient.OIDCTenant
 	return nil
 }
 
-func (m *AuthMiddleware) validateClaims(t *jwt.Token, ks *oidcclient.OIDCTenant) error {
+func (m *Middleware) validateClaims(t *jwt.Token, ks *oidcclient.OIDCTenant) error {
 	c := t.Claims.(*OIDCClaims)
 
 	if c.ExpiresAt == nil {
@@ -99,7 +99,7 @@ func (m *AuthMiddleware) validateClaims(t *jwt.Token, ks *oidcclient.OIDCTenant)
 	return err
 }
 
-func (m *AuthMiddleware) getOIDCTenant(t *jwt.Token) (*oidcclient.OIDCTenant, error) {
+func (m *Middleware) getOIDCTenant(t *jwt.Token) (*oidcclient.OIDCTenant, error) {
 	claims, ok := t.Claims.(*OIDCClaims)
 	if !ok {
 		return nil, fmt.Errorf("token is unverifiable: internal validation error during type assertion: expected *OIDCClaims, got %T", t.Claims)

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -16,7 +16,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 	if err != nil {
 		t.Errorf("error creating test setup: %v", err)
 	}
-	m := NewAuthMiddleware(env.IASConfig{
+	m := NewMiddleware(env.IASConfig{
 		ClientID:     oidcMockServer.Config.ClientID,
 		ClientSecret: oidcMockServer.Config.ClientSecret,
 		URL:          oidcMockServer.Config.URL,

--- a/samples/middleware.go
+++ b/samples/middleware.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	authMiddleware := auth.NewAuthMiddleware(config, auth.Options{})
+	authMiddleware := auth.NewMiddleware(config, auth.Options{})
 	r.Use(authMiddleware.Handler)
 
 	r.HandleFunc("/helloWorld", helloWorld).Methods("GET")

--- a/samples/middleware.go
+++ b/samples/middleware.go
@@ -24,7 +24,7 @@ func main() {
 		panic(err)
 	}
 	authMiddleware := auth.NewMiddleware(config, auth.Options{})
-	r.Use(authMiddleware.Handler)
+	r.Use(authMiddleware.AuthenticationHandler)
 
 	r.HandleFunc("/helloWorld", helloWorld).Methods("GET")
 


### PR DESCRIPTION
Rename the `AuthMiddleware` to `Middleware` only, because types should not start with the respective package name. Furthermore the `Handler` function should contain a more verbose name like `EnforceClaims`. This also allows new middleware handlers if required.

Feel free to discuss :-)