### PR TITLE
SECAUTH-1475 Calls jwks endpoint with x-zone_uuid header

### DIFF
--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -190,6 +190,13 @@ func TestEnd2End(t *testing.T) {
 				Build(),
 			claims:  oidcMockServer.DefaultClaims(),
 			wantErr: true,
+		}, {
+			name:   "jwks rejects zone",
+			header: oidcMockServer.DefaultHeaders(),
+			claims: mocks.NewOIDCClaimsBuilder(oidcMockServer.DefaultClaims()).
+				ZoneID("22222222-3333-4444-5555-666666666666").
+				Build(),
+			wantErr: true,
 		},
 		// TODO: ProviderJSON with different issuer key (e.g. iss)
 	}

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -197,6 +197,13 @@ func TestEnd2End(t *testing.T) {
 				ZoneID("22222222-3333-4444-5555-666666666666").
 				Build(),
 			wantErr: true,
+		}, {
+			name:   "lib rejects unaccepted zone again",
+			header: oidcMockServer.DefaultHeaders(),
+			claims: mocks.NewOIDCClaimsBuilder(oidcMockServer.DefaultClaims()).
+				ZoneID("22222222-3333-4444-5555-666666666666").
+				Build(),
+			wantErr: true,
 		},
 		// TODO: ProviderJSON with different issuer key (e.g. iss)
 	}

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -54,7 +54,7 @@ func (m *Middleware) verifySignature(t Token, keySet *oidcclient.OIDCTenant) (er
 	}
 
 	// parse and verify signature
-	jwks, err := keySet.GetJWKs()
+	jwks, err := keySet.GetJWKs(t.ZoneID())
 	if err != nil {
 		return err
 	}

--- a/mocks/mockServer.go
+++ b/mocks/mockServer.go
@@ -25,8 +25,6 @@ import (
 	"time"
 )
 
-const badRequest int = 400
-
 // MockServer serves as a single tenant OIDC mock server for tests.
 // Requests to the MockServer must be done by the mockServers client: MockServer.Server.Client()
 type MockServer struct {
@@ -106,7 +104,7 @@ func (m *MockServer) JWKsHandler(w http.ResponseWriter, _ *http.Request) {
 // in reality it returns "{ \"msg\":\"Invalid zone_uuid provided\" }"
 func (m *MockServer) JWKsHandlerInvalidZone(w http.ResponseWriter, _ *http.Request) {
 	m.JWKsHitCounter++
-	w.WriteHeader(badRequest)
+	w.WriteHeader(http.StatusBadRequest)
 }
 
 // SignToken signs the provided OIDCClaims and header fields into a base64 encoded JWT token signed by the MockServer.

--- a/mocks/mockServer.go
+++ b/mocks/mockServer.go
@@ -60,7 +60,8 @@ func NewOIDCMockServer() (*MockServer, error) {
 	}
 
 	r.HandleFunc("/.well-known/openid-configuration", mockServer.WellKnownHandler).Methods("GET")
-	r.HandleFunc("/oauth2/certs", mockServer.JWKsHandler).Methods("GET")
+	r.HandleFunc("/oauth2/certs", mockServer.JWKsHandler).Methods("GET").Headers("x-zone_uuid", mockServer.DefaultClaims().ZoneID)
+	r.HandleFunc("/oauth2/certs", mockServer.JWKsHandlerInvalidZone).Methods("GET").Headers("x-zone_uuid", "22222222-3333-4444-5555-666666666666")
 
 	return mockServer, nil
 }
@@ -83,7 +84,7 @@ func (m *MockServer) WellKnownHandler(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write(payload)
 }
 
-// JWKsHandler is the http handler which answers requests to the mock servers OIDC discovery endpoint.
+// JWKsHandler is the http handler which answers requests to the JWKS endpoint.
 func (m *MockServer) JWKsHandler(w http.ResponseWriter, _ *http.Request) {
 	m.JWKsHitCounter++
 	key := &JSONWebKey{
@@ -97,6 +98,13 @@ func (m *MockServer) JWKsHandler(w http.ResponseWriter, _ *http.Request) {
 	keySet := JSONWebKeySet{Keys: []*JSONWebKey{key}}
 	payload, _ := json.Marshal(keySet)
 	_, _ = w.Write(payload)
+}
+
+// JWKsHandlerInvalidZone is the http handler which answers invalid requests to the JWKS endpoint.
+// in reality it returns "{ \"msg\":\"Invalid zone_uuid provided\" }"
+func (m *MockServer) JWKsHandlerInvalidZone(w http.ResponseWriter, _ *http.Request) {
+	m.JWKsHitCounter++
+	w.WriteHeader(400)
 }
 
 // SignToken signs the provided OIDCClaims and header fields into a base64 encoded JWT token signed by the MockServer.

--- a/mocks/mockServer.go
+++ b/mocks/mockServer.go
@@ -25,6 +25,8 @@ import (
 	"time"
 )
 
+const badRequest int = 400
+
 // MockServer serves as a single tenant OIDC mock server for tests.
 // Requests to the MockServer must be done by the mockServers client: MockServer.Server.Client()
 type MockServer struct {
@@ -104,7 +106,7 @@ func (m *MockServer) JWKsHandler(w http.ResponseWriter, _ *http.Request) {
 // in reality it returns "{ \"msg\":\"Invalid zone_uuid provided\" }"
 func (m *MockServer) JWKsHandlerInvalidZone(w http.ResponseWriter, _ *http.Request) {
 	m.JWKsHitCounter++
-	w.WriteHeader(400)
+	w.WriteHeader(badRequest)
 }
 
 // SignToken signs the provided OIDCClaims and header fields into a base64 encoded JWT token signed by the MockServer.

--- a/oidcclient/jwk.go
+++ b/oidcclient/jwk.go
@@ -57,7 +57,7 @@ func (ks *OIDCTenant) GetJWKs(zoneID string) (jwk.Set, error) {
 		if isZoneAccepted {
 			return ks.jwks, nil
 		}
-		return nil, fmt.Errorf("Severe Security issue: zone_uuid %v is still not accepted", zoneID)
+		return nil, fmt.Errorf("severe Security issue: zone_uuid %v is still not accepted", zoneID)
 	}
 	updatedKeys, err := ks.updateKeys(zoneID)
 	if err != nil {
@@ -176,13 +176,4 @@ func unmarshalResponse(r *http.Response, body []byte, v interface{}) error {
 	}
 
 	return fmt.Errorf("expected Content-Type = application/json, got %q: %v", ct, err)
-}
-
-func contains(arr []string, str string) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
-		}
-	}
-	return false
 }

--- a/oidcclient/jwk.go
+++ b/oidcclient/jwk.go
@@ -28,9 +28,9 @@ type OIDCTenant struct {
 	acceptedZoneIds map[string]bool
 	httpClient      *http.Client
 	// A set of cached keys and their expiry.
-	jwks            jwk.Set
-	jwksExpiry      time.Time
-	mu              sync.RWMutex
+	jwks       jwk.Set
+	jwksExpiry time.Time
+	mu         sync.RWMutex
 }
 
 type updateKeysResult struct {

--- a/oidcclient/jwk.go
+++ b/oidcclient/jwk.go
@@ -57,7 +57,7 @@ func (ks *OIDCTenant) GetJWKs(zoneID string) (jwk.Set, error) {
 		if isZoneAccepted {
 			return ks.jwks, nil
 		}
-		return nil, fmt.Errorf("severe Security issue: zone_uuid %v is still not accepted", zoneID)
+		return nil, fmt.Errorf("severe security issue: zone_uuid %v is still not accepted", zoneID)
 	}
 	updatedKeys, err := ks.updateKeys(zoneID)
 	if err != nil {

--- a/oidcclient/jwk.go
+++ b/oidcclient/jwk.go
@@ -24,7 +24,7 @@ const zoneIDHeader = "x-zone_uuid"
 // OIDCTenant represents one IAS tenant correlating with one zone with it's OIDC discovery results and cached JWKs
 type OIDCTenant struct {
 	ProviderJSON    ProviderJSON
-	acceptedZoneIds []string
+	acceptedZoneIds map[string]bool
 	httpClient      *http.Client
 	// A set of cached keys and their expiry.
 	jwks       jwk.Set
@@ -40,6 +40,7 @@ type updateKeysResult struct {
 func NewOIDCTenant(httpClient *http.Client, targetIss *url.URL) (*OIDCTenant, error) {
 	ks := new(OIDCTenant)
 	ks.httpClient = httpClient
+	ks.acceptedZoneIds = make(map[string]bool)
 	err := ks.performDiscovery(targetIss.Host)
 	if err != nil {
 		return nil, err
@@ -50,8 +51,13 @@ func NewOIDCTenant(httpClient *http.Client, targetIss *url.URL) (*OIDCTenant, er
 
 // GetJWKs returns the validation keys either cached or updated ones
 func (ks *OIDCTenant) GetJWKs(zoneID string) (jwk.Set, error) {
-	if time.Now().Before(ks.jwksExpiry) && contains(ks.acceptedZoneIds, zoneID) {
-		return ks.jwks, nil
+	isZoneAccepted, ok := ks.acceptedZoneIds[zoneID]
+
+	if time.Now().Before(ks.jwksExpiry) && ok {
+		if isZoneAccepted {
+			return ks.jwks, nil
+		}
+		return nil, fmt.Errorf("Severe Security issue: zone_uuid %v is still not accepted", zoneID)
 	}
 	updatedKeys, err := ks.updateKeys(zoneID)
 	if err != nil {
@@ -72,7 +78,6 @@ func (ks *OIDCTenant) updateKeys(zoneID string) (r interface{}, err error) {
 	if err != nil {
 		return result, fmt.Errorf("can't create request to fetch jwk: %v", err)
 	}
-
 	req.Header.Add(zoneIDHeader, zoneID)
 
 	resp, err := ks.httpClient.Do(req)
@@ -82,15 +87,14 @@ func (ks *OIDCTenant) updateKeys(zoneID string) (r interface{}, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		ks.acceptedZoneIds[zoneID] = false
 		return result, fmt.Errorf("failed to fetch jwks from remote for x-zone_uuid %s: %v (%s)", zoneID, err, resp.Body)
 	}
-
-	ks.acceptedZoneIds = append(ks.acceptedZoneIds, zoneID)
+	ks.acceptedZoneIds[zoneID] = true
 	jwks, err := jwk.ParseReader(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse JWK set: %w", err)
 	}
-
 	result.keys = jwks
 	// If the server doesn't provide cache control headers, assume the keys expire in 15min.
 	result.expiry = time.Now().Add(defaultJwkExpiration)

--- a/oidcclient/jwk.go
+++ b/oidcclient/jwk.go
@@ -74,7 +74,7 @@ func (ks *OIDCTenant) readJWKsFromMemory(zoneID string) (jwk.Set, error) {
 		if isZoneAccepted {
 			return ks.jwks, nil
 		}
-		return nil, fmt.Errorf("severe security issue: zone_uuid %v is not accepted by the identity service tenant", zoneID)
+		return nil, fmt.Errorf("zone_uuid %v is not accepted by the identity service tenant", zoneID)
 	}
 	return nil, nil
 }

--- a/oidcclient/jwk_test.go
+++ b/oidcclient/jwk_test.go
@@ -64,8 +64,8 @@ func TestProviderJSON_assertMandatoryFieldsPresent(t *testing.T) {
 
 func TestOIDCTenant_ReadJWKs(t *testing.T) {
 	type fields struct {
-		Duration time.Duration
-		ZoneID string
+		Duration         time.Duration
+		ZoneID           string
 		ExpectedErrorMsg string
 	}
 	tests := []struct {
@@ -172,11 +172,11 @@ func NewRouter() (r *mux.Router) {
 }
 
 func ReturnJWKS(writer http.ResponseWriter, request *http.Request) {
-	writer.Write([]byte(jwksJSONString))
+	_, _ = writer.Write([]byte(jwksJSONString))
 }
 
 func ReturnInvalidJWKS(writer http.ResponseWriter, request *http.Request) {
-	writer.Write([]byte("\"kid\":\"default-kid-ias\""))
+	_, _ = writer.Write([]byte("\"kid\":\"default-kid-ias\""))
 }
 
 func ReturnInvalidZone(writer http.ResponseWriter, request *http.Request) {

--- a/oidcclient/jwk_test.go
+++ b/oidcclient/jwk_test.go
@@ -87,7 +87,7 @@ func TestOIDCTenant_ReadJWKs(t *testing.T) {
 			fields: fields{
 				Duration:         2 * time.Second,
 				ZoneID:           "unknown-zone-id",
-				ExpectedErrorMsg: "severe security issue: zone_uuid unknown-zone-id is not accepted by the identity service tenant",
+				ExpectedErrorMsg: "zone_uuid unknown-zone-id is not accepted by the identity service tenant",
 			},
 			wantErr:          true,
 			wantProviderJSON: false,

--- a/oidcclient/jwk_test.go
+++ b/oidcclient/jwk_test.go
@@ -87,7 +87,7 @@ func TestOIDCTenant_ReadJWKs(t *testing.T) {
 			fields: fields{
 				Duration:         2 * time.Second,
 				ZoneID:           "unknown-zone-id",
-				ExpectedErrorMsg: "severe security issue: zone_uuid unknown-zone-id is still not accepted",
+				ExpectedErrorMsg: "severe security issue: zone_uuid unknown-zone-id is not accepted by the identity service tenant",
 			},
 			wantErr:          true,
 			wantProviderJSON: false,

--- a/oidcclient/jwk_test.go
+++ b/oidcclient/jwk_test.go
@@ -5,8 +5,18 @@
 package oidcclient
 
 import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/lestrrat-go/jwx/jwk"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
+
+const jwksJSONString = "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"default-kid-ias\",\"e\":\"AQAB\",\"use\":\"sig\",\"n\":\"AJtUGmczI7RHx3Ypqxz9_9mK_tc-vOXojlJcMm0VRvYvMLIDlIfj1BrkC_IYLpS2Vl1OTG8AS0xAgBDEG3EUzVU6JZKuIuuxD-iXrBySBQA2ytTYtCrjHD7osji7wyogxDJ2BtVz9191gjX7AlU_WKFPpViK2a_2bCL0K4vI3M6-EZMp20wbD2gDsoD1JYqag66WnTDtZqJjQm3mv6Ohj59_C8RMOtPSLX4AxoS-n_8lYneaRc2UFm_vZepgricMNIZ4TuoLekb_fDlg7cvRtH61gD8hH7iFvQfpkf9rxoclPSG21qbxV4svUVW27DOd_Ewo3eSRdnSb8ctuGnXQuKE=\"}]}"
 
 func TestProviderJSON_assertMandatoryFieldsPresent(t *testing.T) {
 	type fields struct {
@@ -50,4 +60,125 @@ func TestProviderJSON_assertMandatoryFieldsPresent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOIDCTenant_ReadJWKs(t *testing.T) {
+	type fields struct {
+		Duration time.Duration
+		ZoneID string
+		ExpectedErrorMsg string
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		wantErr          bool
+		wantProviderJSON bool
+	}{
+		{
+			name: "read from cache with accepted zone",
+			fields: fields{
+				Duration:  2 * time.Second,
+				ZoneID: "zone-id",
+			},
+			wantErr:          false,
+			wantProviderJSON: false,
+		}, {
+			name: "read from cache with denied zone",
+			fields: fields{
+				Duration:  2 * time.Second,
+				ZoneID: "unknown-zone-id",
+				ExpectedErrorMsg: "severe security issue: zone_uuid unknown-zone-id is still not accepted",
+			},
+			wantErr:          true,
+			wantProviderJSON: false,
+		},
+		{
+			name: "read from token keys endpoint with accepted zone",
+			fields: fields{
+				Duration:  0,
+				ZoneID: "zone-id",
+			},
+			wantErr:          false,
+			wantProviderJSON: true,
+		}, {
+			name: "read from token keys endpoint with denied zone",
+			fields: fields{
+				Duration:  0,
+				ZoneID: "unknown-zone-id",
+				ExpectedErrorMsg: "error updating JWKs: failed to fetch jwks from remote for x-zone_uuid unknown-zone-id",
+			},
+			wantErr:          true,
+			wantProviderJSON: true,
+		}, {
+			name: "read from token keys endpoint with accepted zone but no jwks response",
+			fields: fields{
+				Duration:  0,
+				ZoneID: "provide-invalidJWKS",
+				ExpectedErrorMsg: "error updating JWKs: failed to fetch jwks from remote: ",
+			},
+			wantErr:          true, // as providerJSON is nil
+			wantProviderJSON: false,
+		}, {
+			name: "read from token keys endpoint with accepted zone provoking parsing error",
+				fields: fields{
+				Duration:  0,
+				ZoneID: "provide-invalidJWKS",
+				ExpectedErrorMsg: "error updating JWKs: failed to parse JWK set: failed to unmarshal JWK set",
+			},
+			wantErr:          true, // as jwks endpoint returns no JSON
+			wantProviderJSON: true,
+		},
+	}
+	for _, tt := range tests {
+		var providerJSON ProviderJSON
+		if (tt.wantProviderJSON) {
+			router := NewRouter()
+			localServer := httptest.NewServer(router)
+			defer localServer.Close()
+			localServerURL, _ := url.Parse(localServer.URL)
+			providerJSON.JWKsURL = fmt.Sprintf("%s/oauth2/certs", localServerURL)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			jwksJSON, _ := jwk.ParseString(jwksJSONString)
+			tenant := OIDCTenant{
+				jwksExpiry:      time.Now().Add(tt.fields.Duration),
+				acceptedZoneIds: map[string]bool{"zone-id": true, "unknown-zone-id": false},
+				httpClient:      http.DefaultClient,
+				jwks:            jwksJSON,
+				ProviderJSON:    providerJSON,
+			}
+			jwks, err := tenant.GetJWKs(tt.fields.ZoneID)
+			if(tt.wantErr) {
+				if (err == nil) {
+					t.Errorf("GetJWKs() does not provide error = %v, zoneID %v", err, tt.fields.ZoneID)
+				}
+				if(!strings.HasPrefix(err.Error(), tt.fields.ExpectedErrorMsg)) {
+					t.Errorf("GetJWKs() does not provide expected error message = %v", err.Error())
+				}
+			} else if (jwks == nil) {
+				t.Errorf("GetJWKs() returns nil = %v, zoneID %v", err, tt.fields.ZoneID)
+			}
+		})
+	}
+}
+
+
+func NewRouter() (r *mux.Router) {
+	r = mux.NewRouter()
+	r.HandleFunc("/oauth2/certs", ReturnJWKS).Methods("GET").Headers("x-zone_uuid", "zone-id")
+	r.HandleFunc("/oauth2/certs", ReturnInvalidZone).Methods("GET").Headers("x-zone_uuid", "unknown-zone-id")
+	r.HandleFunc("/oauth2/certs", ReturnInvalidJWKS).Methods("GET").Headers("x-zone_uuid", "provide-invalidJWKS")
+	return r
+}
+
+func ReturnJWKS(writer http.ResponseWriter, request *http.Request) {
+	writer.Write([]byte(jwksJSONString))
+}
+
+func ReturnInvalidJWKS(writer http.ResponseWriter, request *http.Request) {
+	writer.Write([]byte("\"kid\":\"default-kid-ias\""))
+}
+
+func ReturnInvalidZone(writer http.ResponseWriter, request *http.Request) {
+	writer.WriteHeader(400)
 }


### PR DESCRIPTION
- [x] handles 400 (Bad request) status code
- [x] memorizes the zones that were already accepted or denied for up to 15 minutes
- [x] avoids jwks call in case zone was already accepted and keys are not yet expired
- [x] DOES NOT call jwks endpoints before cache entry gets expired => tokens signed with new token keys are not accepted immediately but after a delay of up to 15 minutes
- [x] test cache handling fro jwks and acceptedZoneIDs
- [x] removes singleFlight here, as GetJWKs is parameterized with zone id 
   - [x] -> implement using `sync.RWMutex` to avoid concurrent remote calls to fetch jwks per zone