### PR TITLE
Fix token validation with custom domain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,6 @@ linters:
     - gocritic
     - gocyclo
     - gofmt
-    - golint
     - gomnd
     - goprintffuncname
     - gosec
@@ -92,6 +91,7 @@ linters:
     - unused
     - varcheck
     - whitespace
+    - revive
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
@@ -101,7 +101,7 @@ issues:
         - gomnd
         - funlen
     - linters:
-      - gocritic
+        - gocritic
       text: "hugeParam:"
   # List of regexps of issue texts to exclude, empty list by default.
   # But independently from this option we use default exclude patterns,

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -6,12 +6,13 @@ package auth
 
 import (
 	"context"
-	"github.com/google/uuid"
-	"github.com/patrickmn/go-cache"
-	"golang.org/x/sync/singleflight"
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/patrickmn/go-cache"
+	"golang.org/x/sync/singleflight"
 )
 
 // The ContextKey type is used as a key for library related values in the go context. See also TokenCtxKey

--- a/auth/token.go
+++ b/auth/token.go
@@ -26,6 +26,14 @@ const (
 // Token is the public API to access claims of the token
 type Token interface {
 	TokenValue() string                                   // TokenValue returns encoded token string
+	Audience() []string                                   // Audience returns "aud" claim, if it doesn't exist empty string is returned
+	Expiration() time.Time                                // Expiration returns "exp" claim, if it doesn't exist empty string is returned
+	IsExpired() bool                                      // IsExpired returns true, if 'exp' claim + leeway time of 1 minute is before current time
+	IssuedAt() time.Time                                  // IssuedAt returns "iat" claim, if it doesn't exist empty string is returned
+	Issuer() string                                       // Issuer returns "iss" claim, if it doesn't exist empty string is returned
+	IasIssuer() string                                    // IasIssuer returns "ias_iss" (only set if custom domains are used) claim, if it doesn't exist the value of Issuer() returned
+	NotBefore() time.Time                                 // NotBefore returns "nbf" claim, if it doesn't exist empty string is returned
+	Subject() string                                      // Subject returns "sub" claim, if it doesn't exist empty string is returned
 	GivenName() string                                    // GivenName returns "given_name" claim, if it doesn't exist empty string is returned
 	FamilyName() string                                   // FamilyName returns "family_name" claim, if it doesn't exist empty string is returned
 	Email() string                                        // Email returns "email" claim, if it doesn't exist empty string is returned
@@ -34,15 +42,6 @@ type Token interface {
 	GetClaimAsString(claim string) (string, error)        // GetClaimAsString returns a custom claim type asserted as string. Returns error if the claim is not available or not a string.
 	GetClaimAsStringSlice(claim string) ([]string, error) // GetClaimAsStringSlice returns a custom claim type asserted as string slice. The claim name is case sensitive. Returns error if the claim is not available or not an array
 	GetAllClaimsAsMap() map[string]interface{}            // GetAllClaimsAsMap returns a map of all claims contained in the token. The claim name is case sensitive. Includes also custom claims
-	// only for internal usage
-	audience() []string    // audience returns "aud" claim, if it doesn't exist empty string is returned
-	expiration() time.Time // expiration returns "exp" claim, if it doesn't exist empty string is returned
-	isExpired() bool       // isExpired returns true, if 'exp' claim + leeway time of 1 minute is before current time
-	issuedAt() time.Time   // issuedAt returns "iat" claim, if it doesn't exist empty string is returned
-	issuer() string        // issuer returns "iss" claim, if it doesn't exist empty string is returned
-	iasIssuer() string     // iasIssuer returns "ias_iss" (only set if custom domains are used) claim, if it doesn't exist the value of Issuer() returned
-	notBefore() time.Time  // notBefore returns "nbf" claim, if it doesn't exist empty string is returned
-	subject() string       // subject returns "sub" claim, if it doesn't exist empty string is returned
 	getJwtToken() jwt.Token
 }
 
@@ -69,40 +68,40 @@ func (t stdToken) TokenValue() string {
 	return t.encodedToken
 }
 
-func (t stdToken) audience() []string {
+func (t stdToken) Audience() []string {
 	return t.jwtToken.Audience()
 }
 
-func (t stdToken) expiration() time.Time {
+func (t stdToken) Expiration() time.Time {
 	return t.jwtToken.Expiration()
 }
 
-func (t stdToken) isExpired() bool {
-	return t.expiration().Add(1 * time.Minute).Before(time.Now())
+func (t stdToken) IsExpired() bool {
+	return t.Expiration().Add(1 * time.Minute).Before(time.Now())
 }
 
-func (t stdToken) issuedAt() time.Time {
+func (t stdToken) IssuedAt() time.Time {
 	return t.jwtToken.IssuedAt()
 }
 
-func (t stdToken) issuer() string {
+func (t stdToken) Issuer() string {
 	return t.jwtToken.Issuer()
 }
 
-func (t stdToken) iasIssuer() string {
+func (t stdToken) IasIssuer() string {
 	// return standard issuer if ias_iss is not set
 	v, err := t.GetClaimAsString(iasIssuer)
 	if errors.Is(err, ErrClaimNotExists) {
-		return t.issuer()
+		return t.Issuer()
 	}
 	return v
 }
 
-func (t stdToken) notBefore() time.Time {
+func (t stdToken) NotBefore() time.Time {
 	return t.jwtToken.NotBefore()
 }
 
-func (t stdToken) subject() string {
+func (t stdToken) Subject() string {
 	return t.jwtToken.Subject()
 }
 

--- a/auth/token.go
+++ b/auth/token.go
@@ -26,14 +26,6 @@ const (
 // Token is the public API to access claims of the token
 type Token interface {
 	TokenValue() string                                   // TokenValue returns encoded token string
-	Audience() []string                                   // Audience returns "aud" claim, if it doesn't exist empty string is returned
-	Expiration() time.Time                                // Expiration returns "exp" claim, if it doesn't exist empty string is returned
-	IsExpired() bool                                      // IsExpired returns true, if 'exp' claim + leeway time of 1 minute is before current time
-	IssuedAt() time.Time                                  // IssuedAt returns "iat" claim, if it doesn't exist empty string is returned
-	Issuer() string                                       // Issuer returns "iss" claim, if it doesn't exist empty string is returned
-	IasIssuer() string                                    // IasIssuer returns "ias_iss" (only set if custom domains are used) claim, if it doesn't exist the value of Issuer() returned
-	NotBefore() time.Time                                 // NotBefore returns "nbf" claim, if it doesn't exist empty string is returned
-	Subject() string                                      // Subject returns "sub" claim, if it doesn't exist empty string is returned
 	GivenName() string                                    // GivenName returns "given_name" claim, if it doesn't exist empty string is returned
 	FamilyName() string                                   // FamilyName returns "family_name" claim, if it doesn't exist empty string is returned
 	Email() string                                        // Email returns "email" claim, if it doesn't exist empty string is returned
@@ -42,6 +34,15 @@ type Token interface {
 	GetClaimAsString(claim string) (string, error)        // GetClaimAsString returns a custom claim type asserted as string. Returns error if the claim is not available or not a string.
 	GetClaimAsStringSlice(claim string) ([]string, error) // GetClaimAsStringSlice returns a custom claim type asserted as string slice. The claim name is case sensitive. Returns error if the claim is not available or not an array
 	GetAllClaimsAsMap() map[string]interface{}            // GetAllClaimsAsMap returns a map of all claims contained in the token. The claim name is case sensitive. Includes also custom claims
+	// only for internal usage
+	audience() []string    // audience returns "aud" claim, if it doesn't exist empty string is returned
+	expiration() time.Time // expiration returns "exp" claim, if it doesn't exist empty string is returned
+	isExpired() bool       // isExpired returns true, if 'exp' claim + leeway time of 1 minute is before current time
+	issuedAt() time.Time   // issuedAt returns "iat" claim, if it doesn't exist empty string is returned
+	issuer() string        // issuer returns "iss" claim, if it doesn't exist empty string is returned
+	iasIssuer() string     // iasIssuer returns "ias_iss" (only set if custom domains are used) claim, if it doesn't exist the value of Issuer() returned
+	notBefore() time.Time  // notBefore returns "nbf" claim, if it doesn't exist empty string is returned
+	subject() string       // subject returns "sub" claim, if it doesn't exist empty string is returned
 	getJwtToken() jwt.Token
 }
 
@@ -68,40 +69,40 @@ func (t stdToken) TokenValue() string {
 	return t.encodedToken
 }
 
-func (t stdToken) Audience() []string {
+func (t stdToken) audience() []string {
 	return t.jwtToken.Audience()
 }
 
-func (t stdToken) Expiration() time.Time {
+func (t stdToken) expiration() time.Time {
 	return t.jwtToken.Expiration()
 }
 
-func (t stdToken) IsExpired() bool {
-	return t.Expiration().Add(1 * time.Minute).Before(time.Now())
+func (t stdToken) isExpired() bool {
+	return t.expiration().Add(1 * time.Minute).Before(time.Now())
 }
 
-func (t stdToken) IssuedAt() time.Time {
+func (t stdToken) issuedAt() time.Time {
 	return t.jwtToken.IssuedAt()
 }
 
-func (t stdToken) Issuer() string {
+func (t stdToken) issuer() string {
 	return t.jwtToken.Issuer()
 }
 
-func (t stdToken) IasIssuer() string {
+func (t stdToken) iasIssuer() string {
 	// return standard issuer if ias_iss is not set
 	v, err := t.GetClaimAsString(iasIssuer)
 	if errors.Is(err, ErrClaimNotExists) {
-		return t.Issuer()
+		return t.issuer()
 	}
 	return v
 }
 
-func (t stdToken) NotBefore() time.Time {
+func (t stdToken) notBefore() time.Time {
 	return t.jwtToken.NotBefore()
 }
 
-func (t stdToken) Subject() string {
+func (t stdToken) subject() string {
 	return t.jwtToken.Subject()
 }
 

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -131,26 +131,26 @@ func TestOIDCClaims_getAllClaimsAsMap(t *testing.T) {
 	}
 }
 
-func TestOIDCClaims_getIasIssuer(t *testing.T) {
+func TestOIDCClaims_getSAPIssuer(t *testing.T) {
 	tests := []struct {
-		name       string
-		iss        string
-		iasIss     string
-		wantIss    string
-		wantIasIss string
+		name          string
+		iss           string
+		iasIss        string
+		WantCustomIss string
+		wantIasIss    string
 	}{
 		{
-			name:       "iss claim only",
-			iss:        "http://localhost:3030",
-			wantIss:    "http://localhost:3030",
-			wantIasIss: "http://localhost:3030",
+			name:          "iss claim only",
+			iss:           "http://localhost:3030",
+			wantIasIss:    "http://localhost:3030",
+			WantCustomIss: "",
 		},
 		{
-			name:       "iss and ias_iss claim",
-			iss:        "http://localhost:3030",
-			iasIss:     "https://custom.oidc-server.com",
-			wantIss:    "http://localhost:3030",
-			wantIasIss: "https://custom.oidc-server.com",
+			name:          "iss and ias_iss claim",
+			iss:           "http://localhost:3030",
+			iasIss:        "https://custom.oidc-server.com",
+			wantIasIss:    "https://custom.oidc-server.com",
+			WantCustomIss: "http://localhost:3030",
 		},
 	}
 	for _, tt := range tests {
@@ -165,13 +165,13 @@ func TestOIDCClaims_getIasIssuer(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while preparing test: %v", err)
 			}
-			issuerActual := token.Issuer()
-			if issuerActual != tt.wantIss {
-				t.Errorf("Issuer() got = %v, want %v", issuerActual, tt.wantIss)
+			issuerActual := token.CustomIssuer()
+			if issuerActual != tt.WantCustomIss {
+				t.Errorf("CustomIssuer() got = %v, want %v", issuerActual, tt.WantCustomIss)
 			}
-			iasIssuerActual := token.IasIssuer()
+			iasIssuerActual := token.Issuer()
 			if iasIssuerActual != tt.wantIasIss {
-				t.Errorf("IasIssuer() got = %v, want %v", iasIssuerActual, tt.wantIasIss)
+				t.Errorf("Issuer() got = %v, want %v", iasIssuerActual, tt.wantIasIss)
 			}
 		})
 	}

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -5,9 +5,10 @@
 package auth
 
 import (
-	"github.com/lestrrat-go/jwx/jwt"
 	"reflect"
 	"testing"
+
+	"github.com/lestrrat-go/jwx/jwt"
 )
 
 func TestToken_getClaimAsString(t *testing.T) {
@@ -139,22 +140,16 @@ func TestOIDCClaims_getIasIssuer(t *testing.T) {
 		wantIasIss string
 	}{
 		{
-			name:    "iss claim only",
-			iss:     "http://localhost:3030",
-			wantIss: "http://localhost:3030",
-		},
-		{
-			name:       "iss claim only - empty string",
+			name:       "iss claim only",
 			iss:        "http://localhost:3030",
-			iasIss:     "",
 			wantIss:    "http://localhost:3030",
-			wantIasIss: "",
+			wantIasIss: "http://localhost:3030",
 		},
 		{
 			name:       "iss and ias_iss claim",
 			iss:        "http://localhost:3030",
 			iasIss:     "https://custom.oidc-server.com",
-			wantIss:    "https://custom.oidc-server.com",
+			wantIss:    "http://localhost:3030",
 			wantIasIss: "https://custom.oidc-server.com",
 		},
 	}
@@ -164,7 +159,9 @@ func TestOIDCClaims_getIasIssuer(t *testing.T) {
 			token, err := NewToken("eyJhbGciOiJIUzI1NiJ9.e30.ZRrHA1JJJW8opsbCGfG_HACGpVUMN_a9IV7pAx_Zmeo")
 			jwtToken := token.getJwtToken()
 			_ = jwtToken.Set("iss", tt.iss)
-			_ = jwtToken.Set("ias_iss", tt.iasIss)
+			if tt.iasIss != "" {
+				_ = jwtToken.Set("ias_iss", tt.iasIss)
+			}
 			if err != nil {
 				t.Errorf("Error while preparing test: %v", err)
 			}

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -165,13 +165,13 @@ func TestOIDCClaims_getIasIssuer(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while preparing test: %v", err)
 			}
-			issuerActual := token.issuer()
+			issuerActual := token.Issuer()
 			if issuerActual != tt.wantIss {
 				t.Errorf("Issuer() got = %v, want %v", issuerActual, tt.wantIss)
 			}
-			iasIssuerActual := token.iasIssuer()
+			iasIssuerActual := token.IasIssuer()
 			if iasIssuerActual != tt.wantIasIss {
-				t.Errorf("iasIssuer() got = %v, want %v", iasIssuerActual, tt.wantIasIss)
+				t.Errorf("IasIssuer() got = %v, want %v", iasIssuerActual, tt.wantIasIss)
 			}
 		})
 	}

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -165,13 +165,13 @@ func TestOIDCClaims_getIasIssuer(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error while preparing test: %v", err)
 			}
-			issuerActual := token.Issuer()
+			issuerActual := token.issuer()
 			if issuerActual != tt.wantIss {
 				t.Errorf("Issuer() got = %v, want %v", issuerActual, tt.wantIss)
 			}
-			iasIssuerActual := token.IasIssuer()
+			iasIssuerActual := token.iasIssuer()
 			if iasIssuerActual != tt.wantIasIss {
-				t.Errorf("IasIssuer() got = %v, want %v", iasIssuerActual, tt.wantIasIss)
+				t.Errorf("iasIssuer() got = %v, want %v", iasIssuerActual, tt.wantIasIss)
 			}
 		})
 	}

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -25,7 +25,7 @@ func (m *Middleware) parseAndValidateJWT(rawToken string) (Token, error) {
 	}
 
 	// get keyset
-	keySet, err := m.getOIDCTenant(token.Issuer(), token.IasIssuer())
+	keySet, err := m.getOIDCTenant(token.Issuer(), token.CustomIssuer())
 	if err != nil {
 		return nil, err
 	}
@@ -94,19 +94,23 @@ func (m *Middleware) validateClaims(t Token, ks *oidcclient.OIDCTenant) error { 
 
 // getOIDCTenant returns an OIDC Tenant with discovered .well-known/openid-configuration.
 //
-// tokenIssuer is the iss claim of the incoming token
+// issuer is the iss (or ias_iss, if set) of the incoming token
 //
-// iasIssuer is the ias_iss claim of the incoming token
-func (m *Middleware) getOIDCTenant(tokenIssuer, iasIssuer string) (*oidcclient.OIDCTenant, error) {
-	issURI, err := m.verifyIssuer(iasIssuer)
+// customIssuer is the iss claim of the incoming token
+func (m *Middleware) getOIDCTenant(issuer, customIssuer string) (*oidcclient.OIDCTenant, error) {
+	issURI, err := m.verifyIssuer(issuer)
 	if err != nil {
 		return nil, err
 	}
 
-	oidcTenant, exp, found := m.oidcTenants.GetWithExpiration(iasIssuer)
+	if customIssuer == "" {
+		customIssuer = issuer
+	}
+
+	oidcTenant, exp, found := m.oidcTenants.GetWithExpiration(issuer)
 	// redo discovery if not found, cache expired, or tokenIssuer is not the same as Issuer on providerJSON (e.g. custom domain config just changed for that tenant)
-	if !found || time.Now().After(exp) || oidcTenant.(*oidcclient.OIDCTenant).ProviderJSON.Issuer != tokenIssuer {
-		newKeySet, err, _ := m.sf.Do(iasIssuer, func() (i interface{}, err error) {
+	if !found || time.Now().After(exp) || oidcTenant.(*oidcclient.OIDCTenant).ProviderJSON.Issuer != customIssuer {
+		newKeySet, err, _ := m.sf.Do(issuer, func() (i interface{}, err error) {
 			set, err := oidcclient.NewOIDCTenant(m.options.HTTPClient, issURI)
 			return set, err
 		})
@@ -123,7 +127,7 @@ func (m *Middleware) getOIDCTenant(tokenIssuer, iasIssuer string) (*oidcclient.O
 func (m *Middleware) verifyIssuer(issuer string) (issURI *url.URL, err error) {
 	issURI, err = url.Parse(issuer)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse Issuer URI: %s", issuer)
+		return nil, fmt.Errorf("unable to parse CustomIssuer URI: %s", issuer)
 	}
 
 	if !matchesDomain(issURI.Host, m.oAuthConfig.GetDomains()) {

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -127,7 +127,7 @@ func (m *Middleware) getOIDCTenant(issuer, customIssuer string) (*oidcclient.OID
 func (m *Middleware) verifyIssuer(issuer string) (issURI *url.URL, err error) {
 	issURI, err = url.Parse(issuer)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse CustomIssuer URI: %s", issuer)
+		return nil, fmt.Errorf("unable to parse issuer URI: %s", issuer)
 	}
 
 	if !matchesDomain(issURI.Host, m.oAuthConfig.GetDomains()) {

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -25,7 +25,7 @@ func (m *Middleware) parseAndValidateJWT(rawToken string) (Token, error) {
 	}
 
 	// get keyset
-	keySet, err := m.getOIDCTenant(token.Issuer(), token.IasIssuer())
+	keySet, err := m.getOIDCTenant(token.issuer(), token.iasIssuer())
 	if err != nil {
 		return nil, err
 	}
@@ -76,15 +76,15 @@ func getHeaders(encodedToken string) (jws.Headers, error) {
 	return msg.Signatures()[0].ProtectedHeaders(), nil
 }
 
-func (m *Middleware) validateClaims(t Token, ks *oidcclient.OIDCTenant) error { // performing IsExpired check, because dgriljalva jwt.Validate() doesn't fail on missing 'exp' claim
-	// performing IsExpired check, because lestrrat-go jwt.Validate() doesn't fail on missing 'exp' claim
-	if t.IsExpired() {
-		return fmt.Errorf("token is expired, exp: %v", t.Expiration())
+func (m *Middleware) validateClaims(t Token, ks *oidcclient.OIDCTenant) error { // performing isExpired check, because dgriljalva jwt.Validate() doesn't fail on missing 'exp' claim
+	// performing isExpired check, because lestrrat-go jwt.Validate() doesn't fail on missing 'exp' claim
+	if t.isExpired() {
+		return fmt.Errorf("token is expired, exp: %v", t.expiration())
 	}
 	err := jwt.Validate(t.getJwtToken(),
 		jwt.WithAudience(m.oAuthConfig.GetClientID()),
 		jwt.WithIssuer(ks.ProviderJSON.Issuer),
-		jwt.WithAcceptableSkew(1*time.Minute)) // to keep leeway in sync with Token.IsExpired
+		jwt.WithAcceptableSkew(1*time.Minute)) // to keep leeway in sync with Token.isExpired
 
 	if err != nil {
 		return fmt.Errorf("claim validation failed: %v", err)

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -7,12 +7,14 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"github.com/lestrrat-go/jwx/jws"
-	"github.com/lestrrat-go/jwx/jwt"
-	"github.com/sap/cloud-security-client-go/oidcclient"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/lestrrat-go/jwx/jws"
+	"github.com/lestrrat-go/jwx/jwt"
+
+	"github.com/sap/cloud-security-client-go/oidcclient"
 )
 
 // parseAndValidateJWT parses the token into its claims, verifies the claims and verifies the signature
@@ -23,7 +25,7 @@ func (m *Middleware) parseAndValidateJWT(rawToken string) (Token, error) {
 	}
 
 	// get keyset
-	keySet, err := m.getOIDCTenant(token.Issuer())
+	keySet, err := m.getOIDCTenant(token.IasIssuer())
 	if err != nil {
 		return nil, err
 	}

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -25,7 +25,7 @@ func (m *Middleware) parseAndValidateJWT(rawToken string) (Token, error) {
 	}
 
 	// get keyset
-	keySet, err := m.getOIDCTenant(token.issuer(), token.iasIssuer())
+	keySet, err := m.getOIDCTenant(token.Issuer(), token.IasIssuer())
 	if err != nil {
 		return nil, err
 	}
@@ -76,15 +76,15 @@ func getHeaders(encodedToken string) (jws.Headers, error) {
 	return msg.Signatures()[0].ProtectedHeaders(), nil
 }
 
-func (m *Middleware) validateClaims(t Token, ks *oidcclient.OIDCTenant) error { // performing isExpired check, because dgriljalva jwt.Validate() doesn't fail on missing 'exp' claim
-	// performing isExpired check, because lestrrat-go jwt.Validate() doesn't fail on missing 'exp' claim
-	if t.isExpired() {
-		return fmt.Errorf("token is expired, exp: %v", t.expiration())
+func (m *Middleware) validateClaims(t Token, ks *oidcclient.OIDCTenant) error { // performing IsExpired check, because dgriljalva jwt.Validate() doesn't fail on missing 'exp' claim
+	// performing IsExpired check, because lestrrat-go jwt.Validate() doesn't fail on missing 'exp' claim
+	if t.IsExpired() {
+		return fmt.Errorf("token is expired, exp: %v", t.Expiration())
 	}
 	err := jwt.Validate(t.getJwtToken(),
 		jwt.WithAudience(m.oAuthConfig.GetClientID()),
 		jwt.WithIssuer(ks.ProviderJSON.Issuer),
-		jwt.WithAcceptableSkew(1*time.Minute)) // to keep leeway in sync with Token.isExpired
+		jwt.WithAcceptableSkew(1*time.Minute)) // to keep leeway in sync with Token.IsExpired
 
 	if err != nil {
 		return fmt.Errorf("claim validation failed: %v", err)

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -70,7 +70,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			set, err := m.getOIDCTenant(token.getJwtToken().Issuer(), token.iasIssuer())
+			set, err := m.getOIDCTenant(token.getJwtToken().Issuer(), token.IasIssuer())
 			if err != nil || set == nil {
 				t.Errorf("unexpected error on getOIDCTenant(), %v", err)
 			}

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -5,11 +5,12 @@
 package auth
 
 import (
-	"github.com/sap/cloud-security-client-go/env"
-	"github.com/sap/cloud-security-client-go/mocks"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/sap/cloud-security-client-go/env"
+	"github.com/sap/cloud-security-client-go/mocks"
 )
 
 func TestAdditionalDomain(t *testing.T) {
@@ -69,7 +70,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			set, err := m.getOIDCTenant(token.getJwtToken().Issuer())
+			set, err := m.getOIDCTenant(token.getJwtToken().Issuer(), token.IasIssuer())
 			if err != nil || set == nil {
 				t.Errorf("unexpected error on getOIDCTenant(), %v", err)
 			}

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -70,7 +70,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			set, err := m.getOIDCTenant(token.getJwtToken().Issuer(), token.IasIssuer())
+			set, err := m.getOIDCTenant(token.getJwtToken().Issuer(), token.iasIssuer())
 			if err != nil || set == nil {
 				t.Errorf("unexpected error on getOIDCTenant(), %v", err)
 			}

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -70,7 +70,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			set, err := m.getOIDCTenant(token.getJwtToken().Issuer(), token.IasIssuer())
+			set, err := m.getOIDCTenant(token.Issuer(), token.CustomIssuer())
 			if err != nil || set == nil {
 				t.Errorf("unexpected error on getOIDCTenant(), %v", err)
 			}

--- a/oidcclient/jwk.go
+++ b/oidcclient/jwk.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/lestrrat-go/jwx/jwk"
-	"github.com/pquerna/cachecontrol"
 	"io"
 	"mime"
 	"net/http"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/pquerna/cachecontrol"
 )
 
 const defaultJwkExpiration = 15 * time.Minute
@@ -173,7 +174,7 @@ type ProviderJSON struct {
 }
 
 func (p ProviderJSON) assertMandatoryFieldsPresent() error {
-	missing := make([]string, 0, 2)
+	var missing []string
 	if p.Issuer == "" {
 		missing = append(missing, "issuer")
 	}


### PR DESCRIPTION
The OIDC discovery endpoint actually sets the issuer to the custom domain name if a custom domain issuer was configured in the IAS tenant. Thus is matches the issuer from the token.

Only for checking the (base) domain and performing the OIDC discovery the non-custom ias_iss claim is used.

Additionally the OIDC discovery cache for a tenant is invalidated if the "iss" claim does not match the discovered Issuer. This happens if the custom domain config of that tenant just changed.  