### PR TITLE
make sure that escape characters are handled with JSON parser

### DIFF
--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -131,6 +131,22 @@ func TestOIDCClaims_getAllClaimsAsMap(t *testing.T) {
 	}
 }
 
+func TestOIDCClaims_parseIssuerWithEscapeChar(t *testing.T) {
+	token, err := NewToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cHM6Ly9zdWJkb21haW4uYWNjb3VudHM0MDAub25kZW1hbmQuY29tIn0.psfkd91nGytry3w4G1xOtq-sz6hRkfCsCqwgy_2TsQQ")
+	if err != nil {
+		t.Errorf("Error while preparing test: %v", err)
+	}
+
+	got, err := token.GetClaimAsString("iss")
+	if err != nil {
+		t.Errorf("GetClaimAsString() error = %v", err)
+	}
+	if got != "https://subdomain.accounts400.ondemand.com" {
+		t.Errorf("GetClaimAsString('iss') got = %v", got)
+	}
+}
+
+
 func TestOIDCClaims_getSAPIssuer(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -132,7 +132,7 @@ func TestOIDCClaims_getAllClaimsAsMap(t *testing.T) {
 }
 
 func TestOIDCClaims_parseIssuerWithEscapeChar(t *testing.T) {
-	token, err := NewToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cHM6Ly9zdWJkb21haW4uYWNjb3VudHM0MDAub25kZW1hbmQuY29tIn0.psfkd91nGytry3w4G1xOtq-sz6hRkfCsCqwgy_2TsQQ")
+	token, err := NewToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cHM6XC9cL3N1YmRvbWFpbi5hY2NvdW50czQwMC5vbmRlbWFuZC5jb20ifQ==.psfkd91nGytry3w4G1xOtq-sz6hRkfCsCqwgy_2TsQQ")
 	if err != nil {
 		t.Errorf("Error while preparing test: %v", err)
 	}
@@ -145,7 +145,6 @@ func TestOIDCClaims_parseIssuerWithEscapeChar(t *testing.T) {
 		t.Errorf("GetClaimAsString('iss') got = %v", got)
 	}
 }
-
 
 func TestOIDCClaims_getSAPIssuer(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Currently identity service provides token issuer which escapes forward slashes, like here:
```json
{
    "iss": "https:\/\/aoxk2addh.accounts400.ondemand.com",
    "azp": "49363701-0c40-4f12-bc3b-46d969c0ea5c",
    ...
}
```
This PR adds a test in order to make sure, that JSON Parser used for JWT decoding handle de-escaping as specified here:  https://www.json.org/json-en.html .