### PR TITLE
Refactor Identity struct and interfaces

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -51,20 +51,20 @@ func ClientCertificateFromCtx(r *http.Request) *Certificate {
 // Middleware is the main entrypoint to the authn client library, instantiate with NewMiddleware. It holds information about the oAuth config and configured options.
 // Use either the ready to use AuthenticationHandler as a middleware or implement your own middleware with the help of Authenticate.
 type Middleware struct {
-	oAuthConfig env.OAuthConfig
+	identity    env.Identity
 	options     Options
 	oidcTenants *cache.Cache // contains *oidcclient.OIDCTenant
 	sf          singleflight.Group
 }
 
 // NewMiddleware instantiates a new Middleware with defaults for not provided Options.
-func NewMiddleware(oAuthConfig env.OAuthConfig, options Options) *Middleware {
+func NewMiddleware(identity env.Identity, options Options) *Middleware {
 	m := new(Middleware)
 
-	if oAuthConfig != nil {
-		m.oAuthConfig = oAuthConfig
+	if identity != nil {
+		m.identity = identity
 	} else {
-		log.Fatal("oAuthConfig must not be nil, please refer to package env for default implementations")
+		log.Fatal("identity must not be nil, please refer to package env for default implementations")
 	}
 	if options.ErrorHandler == nil {
 		options.ErrorHandler = DefaultErrorHandler

--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -6,11 +6,11 @@ package auth
 
 import (
 	"context"
+	"github.com/sap/cloud-security-client-go/env"
 	"log"
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/patrickmn/go-cache"
 	"golang.org/x/sync/singleflight"
 )
@@ -36,19 +36,6 @@ type Options struct {
 	HTTPClient   *http.Client // HTTPClient which is used for OIDC discovery and to retrieve JWKs (JSON Web Keys). Default: basic http.Client with a timeout of 15 seconds
 }
 
-// OAuthConfig interface has to be implemented to instantiate NewMiddleware. For IAS the standard implementation IASConfig from ../env/iasConfig.go package can be used.
-type OAuthConfig interface {
-	GetClientID() string             // Returns the client id of the oAuth client.
-	GetClientSecret() string         // Returns the client secret. Optional
-	GetURL() string                  // Returns the url to the Identity tenant. E.g. https://abcdefgh.accounts.ondemand.com
-	GetDomains() []string            // Returns the domains of the Identity service. E.g. ["accounts.ondemand.com"]
-	GetZoneUUID() uuid.UUID          // Returns the zone uuid. Optional
-	GetProofTokenURL() string        // Returns the proof token url. Optional
-	GetCertificate() string          // Returns the client certificate. Optional
-	GetKey() string                  // Returns the client certificate key. Optional
-	GetCertificateExpiresAt() string // Returns the client certificate expiration time. Optional
-}
-
 // TokenFromCtx retrieves the claims of a request which
 // have been injected before via the auth middleware
 func TokenFromCtx(r *http.Request) Token {
@@ -64,20 +51,20 @@ func ClientCertificateFromCtx(r *http.Request) *Certificate {
 // Middleware is the main entrypoint to the authn client library, instantiate with NewMiddleware. It holds information about the oAuth config and configured options.
 // Use either the ready to use AuthenticationHandler as a middleware or implement your own middleware with the help of Authenticate.
 type Middleware struct {
-	oAuthConfig OAuthConfig
+	oAuthConfig env.OAuthConfig
 	options     Options
 	oidcTenants *cache.Cache // contains *oidcclient.OIDCTenant
 	sf          singleflight.Group
 }
 
 // NewMiddleware instantiates a new Middleware with defaults for not provided Options.
-func NewMiddleware(oAuthConfig OAuthConfig, options Options) *Middleware {
+func NewMiddleware(oAuthConfig env.OAuthConfig, options Options) *Middleware {
 	m := new(Middleware)
 
 	if oAuthConfig != nil {
 		m.oAuthConfig = oAuthConfig
 	} else {
-		log.Fatal("OAuthConfig must not be nil, please refer to package env for default implementations")
+		log.Fatal("oAuthConfig must not be nil, please refer to package env for default implementations")
 	}
 	if options.ErrorHandler == nil {
 		options.ErrorHandler = DefaultErrorHandler

--- a/auth/middleware_test.go
+++ b/auth/middleware_test.go
@@ -261,7 +261,7 @@ func TestEnd2End(t *testing.T) {
 				}
 			} else {
 				if response.StatusCode != 401 {
-					t.Errorf("req to test server succeeded unexpectatly: expected: 401, got: %d", response.StatusCode)
+					t.Errorf("req to test server succeeded unexpectedly: expected: 401, got: %d", response.StatusCode)
 				}
 			}
 			body, _ := io.ReadAll(response.Body)

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -82,7 +82,7 @@ func (m *Middleware) validateClaims(t Token, ks *oidcclient.OIDCTenant) error { 
 		return fmt.Errorf("token is expired, exp: %v", t.Expiration())
 	}
 	err := jwt.Validate(t.getJwtToken(),
-		jwt.WithAudience(m.oAuthConfig.GetClientID()),
+		jwt.WithAudience(m.identity.GetClientID()),
 		jwt.WithIssuer(ks.ProviderJSON.Issuer),
 		jwt.WithAcceptableSkew(1*time.Minute)) // to keep leeway in sync with Token.IsExpired
 
@@ -131,7 +131,7 @@ func (m *Middleware) verifyIssuer(issuer string) (issURI *url.URL, err error) {
 		return nil, fmt.Errorf("unable to parse issuer URI: %s", issuer)
 	}
 
-	if !matchesDomain(issURI.Host, m.oAuthConfig.GetDomains()) {
+	if !matchesDomain(issURI.Host, m.identity.GetDomains()) {
 		return nil, fmt.Errorf("token is unverifiable: unknown server (domain doesn't match)")
 	}
 	return issURI, nil

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -18,7 +18,7 @@ func TestAdditionalDomain(t *testing.T) {
 	if err != nil {
 		t.Errorf("error creating test setup: %v", err)
 	}
-	m := NewMiddleware(env.Identity{
+	m := NewMiddleware(env.DefaultIdentity{
 		ClientID:     oidcMockServer.Config.ClientID,
 		ClientSecret: oidcMockServer.Config.ClientSecret,
 		URL:          oidcMockServer.Config.URL,
@@ -43,7 +43,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 	if err != nil {
 		t.Errorf("error creating test setup: %v", err)
 	}
-	m := NewMiddleware(env.Identity{
+	m := NewMiddleware(env.DefaultIdentity{
 		ClientID:     oidcMockServer.Config.ClientID,
 		ClientSecret: oidcMockServer.Config.ClientSecret,
 		URL:          oidcMockServer.Config.URL,

--- a/env/iasConfig.go
+++ b/env/iasConfig.go
@@ -162,57 +162,57 @@ func readSecretFilesToJSON(serviceInstancePath string, instanceSecretFiles []os.
 	return instanceCredentialsJSON, nil
 }
 
-// GetClientID implements the auth.Identity interface.
+// GetClientID implements the env.Identity interface.
 func (c DefaultIdentity) GetClientID() string {
 	return c.ClientID
 }
 
-// GetClientSecret implements the auth.Identity interface.
+// GetClientSecret implements the env.Identity interface.
 func (c DefaultIdentity) GetClientSecret() string {
 	return c.ClientSecret
 }
 
-// GetURL implements the auth.Identity interface.
+// GetURL implements the env.Identity interface.
 func (c DefaultIdentity) GetURL() string {
 	return c.URL
 }
 
-// GetDomains implements the auth.Identity interface.
+// GetDomains implements the env.Identity interface.
 func (c DefaultIdentity) GetDomains() []string {
 	return c.Domains
 }
 
-// GetZoneUUID implements the auth.Identity interface.
+// GetZoneUUID implements the env.Identity interface.
 func (c DefaultIdentity) GetZoneUUID() uuid.UUID {
 	return c.ZoneUUID
 }
 
-// GetProofTokenURL implements the auth.Identity interface.
+// GetProofTokenURL implements the env.Identity interface.
 func (c DefaultIdentity) GetProofTokenURL() string {
 	return c.ProofTokenURL
 }
 
-// GetOsbURL implements the auth.Identity interface.
+// GetOsbURL implements the env.Identity interface.
 func (c DefaultIdentity) GetOsbURL() string {
 	return c.OsbURL
 }
 
-// GetCertificate implements the auth.Identity interface.
+// GetCertificate implements the env.Identity interface.
 func (c DefaultIdentity) GetCertificate() string {
 	return c.Certificate
 }
 
-// IsCertificateBased implements the auth.Identity interface.
+// IsCertificateBased implements the env.Identity interface.
 func (c DefaultIdentity) IsCertificateBased() bool {
 	return c.Certificate != "" && c.Key != ""
 }
 
-// GetKey implements the auth.Identity interface.
+// GetKey implements the env.Identity interface.
 func (c DefaultIdentity) GetKey() string {
 	return c.Key
 }
 
-// GetCertificateExpiresAt implements the auth.Identity interface.
+// GetCertificateExpiresAt implements the env.Identity interface.
 func (c DefaultIdentity) GetCertificateExpiresAt() string {
 	return c.CertificateExpiresAt
 }

--- a/env/iasConfig.go
+++ b/env/iasConfig.go
@@ -26,8 +26,8 @@ type VCAPServices struct {
 	} `json:"identity"`
 }
 
-// OAuthConfig interface has to be implemented to instantiate NewMiddleware. For IAS the standard implementation IASConfig from ../env/iasConfig.go package can be used.
-type OAuthConfig interface {
+// Identity interface has to be implemented to instantiate NewMiddleware. For IAS the standard implementation IASConfig from ../env/iasConfig.go package can be used.
+type Identity interface {
 	GetClientID() string             // Returns the client id of the oAuth client.
 	GetClientSecret() string         // Returns the client secret. Optional
 	GetURL() string                  // Returns the url to the DefaultIdentity tenant. E.g. https://abcdefgh.accounts.ondemand.com
@@ -162,57 +162,57 @@ func readSecretFilesToJSON(serviceInstancePath string, instanceSecretFiles []os.
 	return instanceCredentialsJSON, nil
 }
 
-// GetClientID implements the auth.OAuthConfig interface.
+// GetClientID implements the auth.Identity interface.
 func (c DefaultIdentity) GetClientID() string {
 	return c.ClientID
 }
 
-// GetClientSecret implements the auth.OAuthConfig interface.
+// GetClientSecret implements the auth.Identity interface.
 func (c DefaultIdentity) GetClientSecret() string {
 	return c.ClientSecret
 }
 
-// GetURL implements the auth.OAuthConfig interface.
+// GetURL implements the auth.Identity interface.
 func (c DefaultIdentity) GetURL() string {
 	return c.URL
 }
 
-// GetDomains implements the auth.OAuthConfig interface.
+// GetDomains implements the auth.Identity interface.
 func (c DefaultIdentity) GetDomains() []string {
 	return c.Domains
 }
 
-// GetZoneUUID implements the auth.OAuthConfig interface.
+// GetZoneUUID implements the auth.Identity interface.
 func (c DefaultIdentity) GetZoneUUID() uuid.UUID {
 	return c.ZoneUUID
 }
 
-// GetProofTokenURL implements the auth.OAuthConfig interface.
+// GetProofTokenURL implements the auth.Identity interface.
 func (c DefaultIdentity) GetProofTokenURL() string {
 	return c.ProofTokenURL
 }
 
-// GetOsbURL implements the auth.OAuthConfig interface.
+// GetOsbURL implements the auth.Identity interface.
 func (c DefaultIdentity) GetOsbURL() string {
 	return c.OsbURL
 }
 
-// GetCertificate implements the auth.OAuthConfig interface.
+// GetCertificate implements the auth.Identity interface.
 func (c DefaultIdentity) GetCertificate() string {
 	return c.Certificate
 }
 
-// IsCertificateBased implements the auth.OAuthConfig interface.
+// IsCertificateBased implements the auth.Identity interface.
 func (c DefaultIdentity) IsCertificateBased() bool {
 	return c.Certificate != "" && c.Key != ""
 }
 
-// GetKey implements the auth.OAuthConfig interface.
+// GetKey implements the auth.Identity interface.
 func (c DefaultIdentity) GetKey() string {
 	return c.Key
 }
 
-// GetCertificateExpiresAt implements the auth.OAuthConfig interface.
+// GetCertificateExpiresAt implements the auth.Identity interface.
 func (c DefaultIdentity) GetCertificateExpiresAt() string {
 	return c.CertificateExpiresAt
 }

--- a/env/iasConfig_test.go
+++ b/env/iasConfig_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 )
 
-var testConfig = &Identity{
+var testConfig = &DefaultIdentity{
 	ClientID:     "cef76757-de57-480f-be92-1d8c1c7abf16",
 	ClientSecret: "[the_CLIENT.secret:3[/abc",
 	Domains:      []string{"accounts400.ondemand.com", "my.arbitrary.domain"},
@@ -27,7 +27,7 @@ func TestGetIASConfig(t *testing.T) {
 		name          string
 		k8sSecretPath string
 		env           string
-		want          *Identity
+		want          *DefaultIdentity
 		wantErr       bool
 	}{
 		{

--- a/mocks/mockServer.go
+++ b/mocks/mockServer.go
@@ -338,6 +338,11 @@ func (c MockConfig) GetCertificateExpiresAt() string {
 	return c.CertificateExpiresAt
 }
 
+// IsCertificateBased implements the auth.OAuthConfig interface.
+func (c MockConfig) IsCertificateBased() bool {
+	return c.Certificate != "" && c.Key != ""
+}
+
 // JSONWebKeySet represents the data which is returned by the tenants /oauth2/certs endpoint
 type JSONWebKeySet struct {
 	Keys []*JSONWebKey `json:"keys"`

--- a/mocks/mockServer.go
+++ b/mocks/mockServer.go
@@ -288,57 +288,57 @@ type MockConfig struct {
 	CertificateExpiresAt string
 }
 
-// GetClientID implements the auth.OAuthConfig interface.
+// GetClientID implements the env.Identity interface.
 func (c MockConfig) GetClientID() string {
 	return c.ClientID
 }
 
-// GetClientSecret implements the auth.OAuthConfig interface.
+// GetClientSecret implements the env.Identity interface.
 func (c MockConfig) GetClientSecret() string {
 	return c.ClientSecret
 }
 
-// GetURL implements the auth.OAuthConfig interface.
+// GetURL implements the env.Identity interface.
 func (c MockConfig) GetURL() string {
 	return c.URL
 }
 
-// GetDomains implements the auth.OAuthConfig interface.
+// GetDomains implements the env.Identity interface.
 func (c MockConfig) GetDomains() []string {
 	return c.Domains
 }
 
-// GetZoneUUID implements the auth.OAuthConfig interface.
+// GetZoneUUID implements the env.Identity interface.
 func (c MockConfig) GetZoneUUID() uuid.UUID {
 	return c.ZoneUUID
 }
 
-// GetProofTokenURL implements the auth.OAuthConfig interface.
+// GetProofTokenURL implements the env.Identity interface.
 func (c MockConfig) GetProofTokenURL() string {
 	return c.ProofTokenURL
 }
 
-// GetOsbURL implements the auth.OAuthConfig interface.
+// GetOsbURL implements the env.Identity interface.
 func (c MockConfig) GetOsbURL() string {
 	return c.OsbURL
 }
 
-// GetCertificate implements the auth.OAuthConfig interface.
+// GetCertificate implements the env.Identity interface.
 func (c MockConfig) GetCertificate() string {
 	return c.Certificate
 }
 
-// GetKey implements the auth.OAuthConfig interface.
+// GetKey implements the env.Identity interface.
 func (c MockConfig) GetKey() string {
 	return c.Key
 }
 
-// GetCertificateExpiresAt implements the auth.OAuthConfig interface.
+// GetCertificateExpiresAt implements the env.Identity interface.
 func (c MockConfig) GetCertificateExpiresAt() string {
 	return c.CertificateExpiresAt
 }
 
-// IsCertificateBased implements the auth.OAuthConfig interface.
+// IsCertificateBased implements the env.Identity interface.
 func (c MockConfig) IsCertificateBased() bool {
 	return c.Certificate != "" && c.Key != ""
 }


### PR DESCRIPTION
- move/rename `auth.OAuthConfig` interface to `env.Identity` and enhance interface incompatible with:
````go
IsCertificateBased() bool 
````
- rename `env.Identity` interface to `env.DefaultIdentity`