### PR TITLE
Make token struct public

### DIFF
--- a/auth/certificate_test.go
+++ b/auth/certificate_test.go
@@ -11,11 +11,12 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/pem"
+	"math/big"
+	"testing"
+
 	"github.com/lestrrat-go/jwx/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"math/big"
-	"testing"
 )
 
 //go:embed testdata/x-forwarded-client-cert.txt
@@ -59,7 +60,7 @@ func generateToken(t *testing.T, claimCnfMemberX5tValue string) Token {
 	err := token.Set(claimCnf, cnfClaim)
 	require.NoError(t, err, "Failed to create token: %v", err)
 
-	return stdToken{jwtToken: token}
+	return StdToken{jwtToken: token}
 }
 
 func convertToPEM(t *testing.T, derCert string) string {

--- a/auth/token.go
+++ b/auth/token.go
@@ -50,7 +50,7 @@ type Token interface {
 	getCnfClaimMember(memberName string) string // getCnfClaimMember returns "cnf" claim. The cnf member name is case sensitive. If it doesn't exist empty string is returned
 }
 
-type stdToken struct {
+type StdToken struct {
 	encodedToken string
 	jwtToken     jwt.Token
 }
@@ -62,34 +62,34 @@ func NewToken(encodedToken string) (Token, error) {
 		return nil, err
 	}
 
-	return stdToken{
+	return StdToken{
 		encodedToken: encodedToken,
 		jwtToken:     decodedToken, // encapsulates jwt.token_gen from github.com/lestrrat-go/jwx/jwt
 	}, nil
 }
 
 // TokenValue returns encoded token string
-func (t stdToken) TokenValue() string {
+func (t StdToken) TokenValue() string {
 	return t.encodedToken
 }
 
-func (t stdToken) Audience() []string {
+func (t StdToken) Audience() []string {
 	return t.jwtToken.Audience()
 }
 
-func (t stdToken) Expiration() time.Time {
+func (t StdToken) Expiration() time.Time {
 	return t.jwtToken.Expiration()
 }
 
-func (t stdToken) IsExpired() bool {
+func (t StdToken) IsExpired() bool {
 	return t.Expiration().Add(1 * time.Minute).Before(time.Now())
 }
 
-func (t stdToken) IssuedAt() time.Time {
+func (t StdToken) IssuedAt() time.Time {
 	return t.jwtToken.IssuedAt()
 }
 
-func (t stdToken) CustomIssuer() string {
+func (t StdToken) CustomIssuer() string {
 	// only return iss if ias_iss does exist
 	if !t.HasClaim(claimIasIssuer) {
 		return ""
@@ -97,7 +97,7 @@ func (t stdToken) CustomIssuer() string {
 	return t.jwtToken.Issuer()
 }
 
-func (t stdToken) Issuer() string {
+func (t StdToken) Issuer() string {
 	// return standard issuer if ias_iss is not set
 	v, err := t.GetClaimAsString(claimIasIssuer)
 	if errors.Is(err, ErrClaimNotExists) {
@@ -106,35 +106,35 @@ func (t stdToken) Issuer() string {
 	return v
 }
 
-func (t stdToken) NotBefore() time.Time {
+func (t StdToken) NotBefore() time.Time {
 	return t.jwtToken.NotBefore()
 }
 
-func (t stdToken) Subject() string {
+func (t StdToken) Subject() string {
 	return t.jwtToken.Subject()
 }
 
-func (t stdToken) GivenName() string {
+func (t StdToken) GivenName() string {
 	v, _ := t.GetClaimAsString(claimGivenName)
 	return v
 }
 
-func (t stdToken) FamilyName() string {
+func (t StdToken) FamilyName() string {
 	v, _ := t.GetClaimAsString(claimFamilyName)
 	return v
 }
 
-func (t stdToken) Email() string {
+func (t StdToken) Email() string {
 	v, _ := t.GetClaimAsString(claimEmail)
 	return v
 }
 
-func (t stdToken) ZoneID() string {
+func (t StdToken) ZoneID() string {
 	v, _ := t.GetClaimAsString(claimSapGlobalZoneID)
 	return v
 }
 
-func (t stdToken) UserUUID() string {
+func (t StdToken) UserUUID() string {
 	v, _ := t.GetClaimAsString(claimSapGlobalUserID)
 	return v
 }
@@ -142,12 +142,12 @@ func (t stdToken) UserUUID() string {
 // ErrClaimNotExists shows that the requested custom claim does not exist in the token
 var ErrClaimNotExists = errors.New("claim does not exist in the token")
 
-func (t stdToken) HasClaim(claim string) bool {
+func (t StdToken) HasClaim(claim string) bool {
 	_, exists := t.jwtToken.Get(claim)
 	return exists
 }
 
-func (t stdToken) GetClaimAsString(claim string) (string, error) {
+func (t StdToken) GetClaimAsString(claim string) (string, error) {
 	value, exists := t.jwtToken.Get(claim)
 	if !exists {
 		return "", ErrClaimNotExists
@@ -159,7 +159,7 @@ func (t stdToken) GetClaimAsString(claim string) (string, error) {
 	return stringValue, nil
 }
 
-func (t stdToken) GetClaimAsStringSlice(claim string) ([]string, error) {
+func (t StdToken) GetClaimAsStringSlice(claim string) ([]string, error) {
 	value, exists := t.jwtToken.Get(claim)
 	if !exists {
 		return nil, ErrClaimNotExists
@@ -171,12 +171,12 @@ func (t stdToken) GetClaimAsStringSlice(claim string) ([]string, error) {
 	return res, nil
 }
 
-func (t stdToken) GetAllClaimsAsMap() map[string]interface{} {
+func (t StdToken) GetAllClaimsAsMap() map[string]interface{} {
 	mapClaims, _ := t.jwtToken.AsMap(context.TODO()) // err can not really occur on jwt.Token
 	return mapClaims
 }
 
-func (t stdToken) GetClaimAsMap(claim string) (map[string]interface{}, error) {
+func (t StdToken) GetClaimAsMap(claim string) (map[string]interface{}, error) {
 	value, exists := t.jwtToken.Get(claim)
 	if !exists {
 		return nil, ErrClaimNotExists
@@ -188,11 +188,11 @@ func (t stdToken) GetClaimAsMap(claim string) (map[string]interface{}, error) {
 	return res, nil
 }
 
-func (t stdToken) getJwtToken() jwt.Token {
+func (t StdToken) getJwtToken() jwt.Token {
 	return t.jwtToken
 }
 
-func (t stdToken) getCnfClaimMember(memberName string) string {
+func (t StdToken) getCnfClaimMember(memberName string) string {
 	cnfClaim, err := t.GetClaimAsMap(claimCnf)
 	if errors.Is(err, ErrClaimNotExists) || cnfClaim == nil {
 		return ""

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -47,7 +47,7 @@ func TestToken_getClaimAsString(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error preparing test: %v", err)
 			}
-			stdToken := stdToken{
+			stdToken := StdToken{
 				jwtToken: token,
 			}
 			got, err := stdToken.GetClaimAsString(tt.claimArg)
@@ -104,7 +104,7 @@ func TestOIDCClaims_getClaimAsStringSlice(t *testing.T) {
 			if err != nil {
 				t.Errorf("Error preparing test: %v", err)
 			}
-			stdToken := stdToken{
+			stdToken := StdToken{
 				jwtToken: token,
 			}
 			got, err := stdToken.GetClaimAsStringSlice(tt.claimArg)


### PR DESCRIPTION
The token struct should be public so that consumer can use it easily to write own test cases.

We have the requirement to write test cases for a component which expects a token as input. It's overkill to use the provided mock server to sign a new token for this test case. Instead we just want to create a token struct with the expected inputs ourself.