### PR TITLE
Making validation of raw token public

### DIFF
--- a/auth/middleware.go
+++ b/auth/middleware.go
@@ -117,7 +117,7 @@ func (m *Middleware) AuthenticateWithProofOfPossession(r *http.Request) (Token, 
 		return Token{}, nil, err
 	}
 
-	token, err := m.parseAndValidateJWT(rawToken)
+	token, err := m.ParseAndValidateJWT(rawToken)
 	if err != nil {
 		return Token{}, nil, err
 	}

--- a/auth/validator.go
+++ b/auth/validator.go
@@ -17,8 +17,8 @@ import (
 	"github.com/sap/cloud-security-client-go/oidcclient"
 )
 
-// parseAndValidateJWT parses the token into its claims, verifies the claims and verifies the signature
-func (m *Middleware) parseAndValidateJWT(rawToken string) (Token, error) {
+// ParseAndValidateJWT parses the token into its claims, verifies the claims and verifies the signature
+func (m *Middleware) ParseAndValidateJWT(rawToken string) (Token, error) {
 	token, err := NewToken(rawToken)
 	if err != nil {
 		return Token{}, err

--- a/auth/validator_test.go
+++ b/auth/validator_test.go
@@ -34,7 +34,7 @@ func TestAdditionalDomain(t *testing.T) {
 		t.Errorf("unable to sign provided test token: %v", err)
 	}
 
-	_, err = m.parseAndValidateJWT(rawToken)
+	_, err = m.ParseAndValidateJWT(rawToken)
 	if err != nil {
 		t.Error("unexpected error: ", err.Error())
 	}
@@ -59,7 +59,7 @@ func TestAuthMiddleware_getOIDCTenant(t *testing.T) {
 		t.Errorf("unable to sign provided test token: %v", err)
 	}
 
-	token, err := m.parseAndValidateJWT(rawToken)
+	token, err := m.ParseAndValidateJWT(rawToken)
 	if err != nil {
 		t.Errorf("unable to parse provided test token: %v", err)
 	}


### PR DESCRIPTION
To support token validation when no http request is involved, the actual raw token validation is exposed to the lib consumer.